### PR TITLE
Update JsonParser.java

### DIFF
--- a/src/org/mozilla/javascript/json/JsonParser.java
+++ b/src/org/mozilla/javascript/json/JsonParser.java
@@ -95,7 +95,7 @@ public class JsonParser {
         }
         String id;
         Object value;
-        boolean needsComma = false;
+        boolean needsComma = true;
         while (pos < length) {
             char c = src.charAt(pos++);
             switch(c) {


### PR DESCRIPTION
To recognize a string like [, "a", "b"], because browsers correctly handle such code.