### PR TITLE
NativeMath: fix Math.clz32 bug caused by rounding errors

### DIFF
--- a/src/org/mozilla/javascript/NativeMath.java
+++ b/src/org/mozilla/javascript/NativeMath.java
@@ -185,7 +185,31 @@ final class NativeMath extends ScriptableObject {
         if (n == 0) {
             return Double32;
         }
-        return Double.valueOf(31 - Math.floor(Math.log(n >>> 0) * LOG2E));
+        int place = 0;
+        if ((n & 0xFFFF0000) != 0) {
+            place += 16;
+            n >>>= 16;
+        }
+        if ((n & 0xFF00) != 0) {
+            place += 8;
+            n >>>= 8;
+        }
+        if ((n & 0xF0) != 0) {
+            place += 4;
+            n >>>= 4;
+        }
+        if ((n & 0b1100) != 0) {
+            place += 2;
+            n >>>= 2;
+        }
+        if ((n & 0b10) != 0) {
+            place += 1;
+            n >>>= 1;
+        }
+        if ((n & 0b1) != 0) {
+            place += 1;
+        }
+        return Double.valueOf(32 - place);
     }
 
     private static Object cos(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {


### PR DESCRIPTION
#### This PR does the following:

- Fix a bug in `NativeMath.clz32()` where rounding errors can change the result when using logarithms to find the number of digits.

#### These tests showcase the buggy behavior of the current implementation.
```html
<!DOCTYPE html>
<html>
<head>
<script>
function clz32(num) {
  console.log(Math.clz32(num));
}

clz32(64); 		// expected 25, got 26
clz32(0);  		// 32
clz32(0x00000001);	// 31
clz32(0x00000002);	// 30
clz32(0x00000004);	// 29
clz32(0x00000008);	// expected 28, got 29
clz32(0x000000010);	// 27
clz32(0x00000020);	// 26
clz32(0x00000040);	// expected 25, got 26
clz32(0x00000080);	// expected 24, got 25
clz32(0x00000100);	// 23
clz32(0x00000200);	// 22
clz32(0x00000400);	// 21
clz32(0x00000800);	// 20
clz32(0x00001000);	// expected 19, got 20
clz32(0x00002000);	// expected 18, got 19
clz32(0x00004000);	// expected 17, got 18
clz32(0x00008000);	// 16
clz32(0x00010000);	// 15
clz32(0x00020000);	// 14
clz32(0x00040000);	// 13
clz32(0x00080000);	// 12
clz32(0x00100000);	// 11
clz32(0x00200000);	// 10
clz32(0x00400000);	// 9
clz32(0x00800000);	// 8
clz32(0x01000000);	// expected 7, got 8
clz32(0x02000000);	// 6
clz32(0x04000000);	// expected 5, got 6
clz32(0x08000000);	// 4
clz32(0x10000000);	// expected 3, got 4
clz32(0x20000000);	// 2
clz32(0x40000000);	// 1
clz32(0x80000000);	// 0
clz32(0xFFFFFFFF);	// 0
clz32(0xFFFF0000);	// 0
clz32(0x0000FF00);	// 16
clz32(0x000000F0);	// 24
clz32(0b1100);		// 28
clz32(0b0010);		// 30
clz32(-0);		// 32
clz32(-1);		// 0
clz32(-100);		// 0
clz32(1.9);		// 31
clz32(Number.POSITIVE_INFINITY); // 32
clz32(Number.NEGATIVE_INFINITY); // 32
clz32(Number.NaN);	// 32
clz32(0x1_0000_0100);	// 23
</script>
</head>
<body>
</body>
</html>


```

#### Remark
These are the tests we're using but it's in our format so I couldn't add it to htmlunit sorry. 