### PR TITLE
Fix unwanted behavior of NativeString when used with RegExp

### DIFF
--- a/src/org/mozilla/javascript/NativeString.java
+++ b/src/org/mozilla/javascript/NativeString.java
@@ -463,10 +463,12 @@ final class NativeString extends IdScriptableObject {
                     String thisString =
                             ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, f));
                     if (args.length > 0 && args[0] instanceof NativeRegExp) {
-                        throw ScriptRuntime.typeErrorById(
-                                "msg.first.arg.not.regexp",
-                                String.class.getSimpleName(),
-                                f.getFunctionName());
+                        if (NativeBoolean.isTrue(ScriptableObject.getProperty(ScriptableObject.ensureScriptable(args[0]), SymbolKey.MATCH))) {
+                            throw ScriptRuntime.typeErrorById(
+                                    "msg.first.arg.not.regexp",
+                                    String.class.getSimpleName(),
+                                    f.getFunctionName());
+                        }
                     }
 
                     int idx = js_indexOf(id, thisString, args);


### PR DESCRIPTION
### This PR does the following:

- Fix an issue when `String.includes/startsWith/endsWith` throw `TypeError` when the first argument is a regex, even if [Symbol.match](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/match) of that regex has been set to false.

  > This function is also used to identify [if objects have the behavior of regular expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#special_handling_for_regexes). For example, the methods [String.prototype.startsWith()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith), [String.prototype.endsWith()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith) and [String.prototype.includes()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes), check if their first argument is a regular expression and will throw a [TypeError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) if they are. Now, if the match symbol is set to false (or a [Falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) value except undefined), it indicates that the object is not intended to be used as a regular expression object.


#### These tests showcase the buggy behavior of the current implementation.
```html
<!DOCTYPE html>
<html>
<head>
<script>
var regExp = /./;
try {
  console.log("/./".includes(regExp))
} catch (e) {
  console.log(e); // TypeError: First argument to String.prototype.includes must not be a regular expression
  regExp[Symbol.match] = false;
  console.log("/./".includes(regExp)) // expected: true, got TypeError
}
</script>
</head>
<body>
</body>
</html>
```