### PR TITLE
Correctly assign the value of arguments[Symbol.iterator]

### DIFF
--- a/src/org/mozilla/javascript/Arguments.java
+++ b/src/org/mozilla/javascript/Arguments.java
@@ -41,7 +41,7 @@ class Arguments extends IdScriptableObject {
             callerObj = NOT_FOUND;
         }
 
-        defineProperty(SymbolKey.ITERATOR, iteratorMethod, ScriptableObject.DONTENUM);
+        defineProperty(SymbolKey.ITERATOR, TopLevel.getBuiltinPrototype(parent, TopLevel.Builtins.Array).get("values", parent), ScriptableObject.DONTENUM);
     }
 
     public Arguments(final Arguments original) {
@@ -422,22 +422,6 @@ class Arguments extends IdScriptableObject {
     public Object getDefaultValue(Class<?> typeHint) {
         return "[object " + getClassName() + "]";
     }
-
-    private static BaseFunction iteratorMethod =
-            new BaseFunction() {
-                private static final long serialVersionUID = 4239122318596177391L;
-
-                @Override
-                public Object call(
-                        Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-                    // TODO : call %ArrayProto_values%
-                    // 9.4.4.6 CreateUnmappedArgumentsObject(argumentsList)
-                    //  1. Perform DefinePropertyOrThrow(obj, @@iterator, PropertyDescriptor
-                    // {[[Value]]:%ArrayProto_values%,
-                    //     [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true}).
-                    return new NativeArrayIterator(scope, thisObj, ARRAY_ITERATOR_TYPE.VALUES);
-                }
-            };
 
     private static class ThrowTypeError extends BaseFunction {
         private static final long serialVersionUID = -744615873947395749L;


### PR DESCRIPTION
### This PR does the following:
- Set the value of [arguments[Symbol.iterator]](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/@@iterator) to `Array.prototype.values()`

### Test cases
- These tests showcase the current & expected behavior of the `arguments` object

```html
<!DOCTYPE html>
<html>
<head>
<script>
(function(){
  // expected: true, current: false
  console.log(arguments[Symbol.iterator] === Array.prototype.values)
  // expected: function call() {...}, current: undefined
  console.log(arguments[Symbol.iterator].call)
}());
</script>
</head>
<body>
</body>
</html>

```