### PR TITLE
NativeProxy: callTrap should be called with value, not descriptor of value

### DIFF
--- a/src/org/mozilla/javascript/NativeProxy.java
+++ b/src/org/mozilla/javascript/NativeProxy.java
@@ -585,9 +585,8 @@ final class NativeProxy extends ScriptableObject implements Callable, Constructa
 
         Callable trap = getTrap(TRAP_SET);
         if (trap != null) {
-            ScriptableObject desc = ScriptableObject.buildDataDescriptor(target, value, EMPTY);
             boolean booleanTrapResult =
-                    ScriptRuntime.toBoolean(callTrap(trap, new Object[] {target, name, desc}));
+                    ScriptRuntime.toBoolean(callTrap(trap, new Object[] {target, name, value}));
             if (!booleanTrapResult) {
                 return; // false
             }
@@ -643,12 +642,11 @@ final class NativeProxy extends ScriptableObject implements Callable, Constructa
 
         Callable trap = getTrap(TRAP_SET);
         if (trap != null) {
-            ScriptableObject desc = ScriptableObject.buildDataDescriptor(target, value, EMPTY);
             boolean booleanTrapResult =
                     ScriptRuntime.toBoolean(
                             callTrap(
                                     trap,
-                                    new Object[] {target, ScriptRuntime.toString(index), desc}));
+                                    new Object[] {target, ScriptRuntime.toString(index), value}));
             if (!booleanTrapResult) {
                 return; // false
             }
@@ -704,9 +702,8 @@ final class NativeProxy extends ScriptableObject implements Callable, Constructa
 
         Callable trap = getTrap(TRAP_SET);
         if (trap != null) {
-            ScriptableObject desc = ScriptableObject.buildDataDescriptor(target, value, EMPTY);
             boolean booleanTrapResult =
-                    ScriptRuntime.toBoolean(callTrap(trap, new Object[] {target, key, desc}));
+                    ScriptRuntime.toBoolean(callTrap(trap, new Object[] {target, key, value}));
             if (!booleanTrapResult) {
                 return; // false
             }

--- a/testsrc/org/mozilla/javascript/tests/es6/NativeProxyTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/NativeProxyTest.java
@@ -95,6 +95,23 @@ public class NativeProxyTest {
     }
 
     @Test
+    public void testTrapSet() {
+        String js =
+                "var res = '';\n"
+                        + "var proxy = new Proxy({}, {\n"
+                        + "  set(obj, prop, value) {\n"
+                        + "    res += value + ' ' + (value instanceof Array);\n"
+                        + "    obj[prop] = value;\n"
+                        + "    return true;\n"
+                        + "  },\n"
+                        + "});\n"
+                        + "proxy.foo = [1, 2, 3];\n"
+                        + "res";
+
+        testString("1,2,3 true", js);
+    }
+
+    @Test
     public void apply() {
         String js =
                 "function sum(a, b) {\n"


### PR DESCRIPTION
### This PR does the following
- Fix `NativeProxy.put` so that `callTrap` is called with the parameter `value` instead of a descriptor of `value`.

### Reproducing
This showcases the existing problem

```javascript
var proxy = new Proxy({}, {
  set(obj, prop, value) {
    // expect: [1, 2, 3] true
    // htmlunit: [object Object] false
    // the type of the value has been changed. it's now a NativeObject with the following properties: {"value":[1,2,3],"writable":true,"enumerable":true,"configurable":true} instead of an array.
    console.log(value, value instanceof Array);
    obj[prop] = value;
    return true;
  },
});
proxy.foo = [1, 2, 3];
```