### PR TITLE
NativeDate: refactor to use java.time, fix locales argument

### DIFF
--- a/src/org/mozilla/javascript/NativeDate.java
+++ b/src/org/mozilla/javascript/NativeDate.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Supplier;
 
 /**
  * This class implements the Date native object. See ECMA 15.9.
@@ -29,8 +30,7 @@ final class NativeDate extends IdScriptableObject {
 
     private static final String js_NaN_date_str = "Invalid Date";
 
-    // TODO: we probably shouldn't be hard coding this to be platform dependent
-    private static final ZoneId HOST_TIME_ZONE = ZoneId.systemDefault();
+    private static final Supplier<ZoneId> HOST_TIME_ZONE_SUPPLIER = () -> Context.getCurrentContext().getTimeZone().toZoneId();
 
     static void init(Scriptable scope, boolean sealed) {
         NativeDate obj = new NativeDate();
@@ -1356,7 +1356,7 @@ final class NativeDate extends IdScriptableObject {
                 t = MakeDate(day, TimeWithinDay(t));
             }
             result.append(" (");
-            result.append(timeZoneFormatter.format(Instant.ofEpochMilli((long) t).atZone(HOST_TIME_ZONE)));
+            result.append(timeZoneFormatter.format(Instant.ofEpochMilli((long) t).atZone(HOST_TIME_ZONE_SUPPLIER.get())));
             result.append(')');
         }
         return result.toString();
@@ -1443,7 +1443,7 @@ final class NativeDate extends IdScriptableObject {
             }
         }
 
-        return formatter.format(Instant.ofEpochMilli((long) t).atZone(HOST_TIME_ZONE));
+        return formatter.format(Instant.ofEpochMilli((long) t).atZone(HOST_TIME_ZONE_SUPPLIER.get()));
     }
 
     private static String js_toUTCString(double date) {

--- a/src/org/mozilla/javascript/NativeDate.java
+++ b/src/org/mozilla/javascript/NativeDate.java
@@ -9,6 +9,7 @@ package org.mozilla.javascript;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -1944,9 +1945,10 @@ final class NativeDate extends IdScriptableObject {
 
     // not thread safe
     private static final DateTimeFormatter timeZoneFormatter = DateTimeFormatter.ofPattern("zzz");
-    private static final DateTimeFormatter localeDateTimeFormatter = DateTimeFormatter.ofPattern("MMMM d, yyyy h:mm:ss a z");
-    private static final DateTimeFormatter localeDateFormatter = DateTimeFormatter.ofPattern("MMMM d, yyyy");
-    private static final DateTimeFormatter localeTimeFormatter = DateTimeFormatter.ofPattern("h:mm:ss a z");
+    // use FormatStyle.SHORT for these as per spec of an implementation that has no Intl.DateTimeFormat support
+    private static final DateTimeFormatter localeDateTimeFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT);
+    private static final DateTimeFormatter localeDateFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT);
+    private static final DateTimeFormatter localeTimeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT);
 
     private double date;
 }

--- a/testsrc/org/mozilla/javascript/tests/es6/NativeDateTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/NativeDateTest.java
@@ -221,19 +221,19 @@ public class NativeDateTest {
 
                     {
                         final String res = (String)cx.evaluateString(scope, String.format(js, "\"en-US\""), "test.js", 0, null);
-                        assertEquals("December 18, 2021 2:23:00 PM PST", res);
+                        assertEquals("December 18, 2021 10:23:00 PM GMT", res);
                     }
                     {
                         final String res = (String)cx.evaluateString(scope, String.format(js, "\"de-DE\""), "test.js", 0, null);
-                        assertEquals("Dezember 18, 2021 2:23:00 nachm. PST", res);
+                        assertEquals("Dezember 18, 2021 10:23:00 nachm. GMT", res);
                     }
                     {
                         final String res = (String)cx.evaluateString(scope, String.format(js, "\"ja-JP\""), "test.js", 0, null);
-                        assertEquals("12月 18, 2021 2:23:00 午後 PST", res);
+                        assertEquals("12月 18, 2021 10:23:00 午後 GMT", res);
                     }
                     {
                         final String res = (String)cx.evaluateString(scope, String.format(js, "['foo', 'ja-JP', 'en-US']"), "test.js", 0, null);
-                        assertEquals("12月 18, 2021 2:23:00 午後 PST", res);
+                        assertEquals("12月 18, 2021 10:23:00 午後 GMT", res);
                     }
                     return null;
                 });

--- a/testsrc/org/mozilla/javascript/tests/es6/NativeDateTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/NativeDateTest.java
@@ -212,7 +212,7 @@ public class NativeDateTest {
 
     @Test
     public void toLocaleString() {
-        String js = "new Date('2021-12-18T22:23').toLocaleString(%s)";
+        String js = "new Date('2021-12-18T22:23').%s";
         Utils.runWithAllOptimizationLevels(
                 cx -> {
                     final Scriptable scope = cx.initStandardObjects();
@@ -220,20 +220,36 @@ public class NativeDateTest {
                     cx.setTimeZone(TimeZone.getTimeZone("GMT"));
 
                     {
-                        final String res = (String)cx.evaluateString(scope, String.format(js, "\"en-US\""), "test.js", 0, null);
-                        assertEquals("December 18, 2021 10:23:00 PM GMT", res);
+                        assertEquals("12/18/21, 10:23 PM", cx.evaluateString(scope, String.format(js, "toLocaleString('en-US')"),
+                                "test.js", 0, null));
+                        assertEquals("12/18/21", cx.evaluateString(scope, String.format(js, "toLocaleDateString('en-US')"),
+                                "test.js", 0, null));
+                        assertEquals("10:23 PM", cx.evaluateString(scope, String.format(js, "toLocaleTimeString('en-US')"),
+                                "test.js", 0, null));
                     }
                     {
-                        final String res = (String)cx.evaluateString(scope, String.format(js, "\"de-DE\""), "test.js", 0, null);
-                        assertEquals("Dezember 18, 2021 10:23:00 nachm. GMT", res);
+                        assertEquals("18.12.21, 22:23", cx.evaluateString(scope, String.format(js, "toLocaleString('de-DE')"),
+                                "test.js", 0, null));
+                        assertEquals("18.12.21", cx.evaluateString(scope, String.format(js, "toLocaleDateString('de-DE')"),
+                                "test.js", 0, null));
+                        assertEquals("22:23", cx.evaluateString(scope, String.format(js, "toLocaleTimeString('de-DE')"),
+                                "test.js", 0, null));
                     }
                     {
-                        final String res = (String)cx.evaluateString(scope, String.format(js, "\"ja-JP\""), "test.js", 0, null);
-                        assertEquals("12月 18, 2021 10:23:00 午後 GMT", res);
+                        assertEquals("2021/12/18 22:23", cx.evaluateString(scope, String.format(js, "toLocaleString('ja-JP')"),
+                                "test.js", 0, null));
+                        assertEquals("2021/12/18", cx.evaluateString(scope, String.format(js, "toLocaleDateString('ja-JP')"),
+                                "test.js", 0, null));
+                        assertEquals("22:23", cx.evaluateString(scope, String.format(js, "toLocaleTimeString('ja-JP')"),
+                                "test.js", 0, null));
                     }
                     {
-                        final String res = (String)cx.evaluateString(scope, String.format(js, "['foo', 'ja-JP', 'en-US']"), "test.js", 0, null);
-                        assertEquals("12月 18, 2021 10:23:00 午後 GMT", res);
+                        assertEquals("2021/12/18 22:23", cx.evaluateString(scope, String.format(js, "toLocaleString(['foo', 'ja-JP', 'en-US'])"),
+                                "test.js", 0, null));
+                        assertEquals("2021/12/18", cx.evaluateString(scope, String.format(js, "toLocaleDateString(['foo', 'ja-JP', 'en-US'])"),
+                                "test.js", 0, null));
+                        assertEquals("22:23", cx.evaluateString(scope, String.format(js, "toLocaleTimeString(['foo', 'ja-JP', 'en-US'])"),
+                                "test.js", 0, null));
                     }
                     return null;
                 });

--- a/testsrc/org/mozilla/javascript/tests/es6/NativeDateTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/NativeDateTest.java
@@ -83,6 +83,22 @@ public class NativeDateTest {
     }
 
     @Test
+    public void ctorDateTimeTokyo() {
+        String js = "new Date('2021-12-18T22:23').toISOString()";
+
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    final Scriptable scope = cx.initStandardObjects();
+                    cx.setLanguageVersion(Context.VERSION_ES6);
+                    cx.setTimeZone(TimeZone.getTimeZone("Asia/Tokyo"));
+
+                    final Object res = cx.evaluateString(scope, js, "test.js", 0, null);
+                    assertEquals("2021-12-18T13:23:00.000Z", res);
+                    return null;
+                });
+    }
+
+    @Test
     public void ctorDate() {
         String js = "new Date('2021-12-18').toISOString()";
 
@@ -174,6 +190,51 @@ public class NativeDateTest {
 
                     final Double res = (Double) cx.evaluateString(scope, js, "test.js", 0, null);
                     assertEquals(300, res.doubleValue(), 0.0001);
+                    return null;
+                });
+    }
+
+    @Test
+    public void timezoneOffsetTokyo() {
+        String js = "new Date(0).getTimezoneOffset()";
+
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    final Scriptable scope = cx.initStandardObjects();
+                    cx.setLanguageVersion(Context.VERSION_ES6);
+                    cx.setTimeZone(TimeZone.getTimeZone("Asia/Tokyo"));
+
+                    final Double res = (Double) cx.evaluateString(scope, js, "test.js", 0, null);
+                    assertEquals(-540, res.doubleValue(), 0.0001);
+                    return null;
+                });
+    }
+
+    @Test
+    public void toLocaleString() {
+        String js = "new Date('2021-12-18T22:23').toLocaleString(%s)";
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    final Scriptable scope = cx.initStandardObjects();
+                    cx.setLanguageVersion(Context.VERSION_ES6);
+                    cx.setTimeZone(TimeZone.getTimeZone("GMT"));
+
+                    {
+                        final String res = (String)cx.evaluateString(scope, String.format(js, "\"en-US\""), "test.js", 0, null);
+                        assertEquals("December 18, 2021 2:23:00 PM PST", res);
+                    }
+                    {
+                        final String res = (String)cx.evaluateString(scope, String.format(js, "\"de-DE\""), "test.js", 0, null);
+                        assertEquals("Dezember 18, 2021 2:23:00 nachm. PST", res);
+                    }
+                    {
+                        final String res = (String)cx.evaluateString(scope, String.format(js, "\"ja-JP\""), "test.js", 0, null);
+                        assertEquals("12月 18, 2021 2:23:00 午後 PST", res);
+                    }
+                    {
+                        final String res = (String)cx.evaluateString(scope, String.format(js, "['foo', 'ja-JP', 'en-US']"), "test.js", 0, null);
+                        assertEquals("12月 18, 2021 2:23:00 午後 PST", res);
+                    }
                     return null;
                 });
     }


### PR DESCRIPTION
### This PR does the following
- Improve `NativeDate` by
~~- Add `Japan Standard Time (JST)` support~~
  - Change to use `DateTimeFormatter` instead of `SimpleDateFormat`
  - Fix [Date.prototype.toLocaleString](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString) currently not handling locales argument
  - Make the formatter use `Context.timezone` instead of system default
  - Use `FormatStyle.SHORT` for the formatter to make it behave more like real browsers when `Intl.DateTimeFormat` is not supported.